### PR TITLE
Fix build settings for proxyMiddleman

### DIFF
--- a/proxyMiddleman_unix.go
+++ b/proxyMiddleman_unix.go
@@ -1,4 +1,4 @@
-//+build darwin unix linux
+// +build !windows
 
 package ieproxy
 


### PR DESCRIPTION
Augh! I should've caught this before but, without this patch, this won't compile on anything outside of osx, unix, and linux.

This should make this be able to compile everywhere.

@mattn there isn't much to review here if you'd like to just merge it in.