### PR TITLE
Additional checks were added to toggle between the registry key LOCAL…

### DIFF
--- a/ieproxy_windows.go
+++ b/ieproxy_windows.go
@@ -168,16 +168,29 @@ func parseRegedit(regedit regeditValues) ProxyConf {
 }
 
 func readRegedit() (values regeditValues, err error) {
-	k, err := registry.OpenKey(registry.CURRENT_USER, `Software\Microsoft\Windows\CurrentVersion\Internet Settings`, registry.QUERY_VALUE)
-	if err != nil {
-		/*	It might be possible that the component/Exe is running under local system account, for which CURRENT_USER
-			is not accessible, hence it should try to read from the key LOCAL_MACHINE.
-			https://docs.microsoft.com/en-us/windows/win32/services/localsystem-account
-		*/
-		k, err = registry.OpenKey(registry.LOCAL_MACHINE, `Software\Microsoft\Windows\CurrentVersion\Internet Settings`, registry.QUERY_VALUE)		
-		if err != nil {
-			return
+	var proxySettingsPerUser uint64 = 1 // 1 is the default value to consider current user
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings`, registry.QUERY_VALUE)
+	if err == nil {
+		//We had used the below variable tempPrxUsrSettings, because the Golang method GetIntegerValue
+		//sets the value to zero even it fails.
+		tempPrxUsrSettings, _, err := k.GetIntegerValue("ProxySettingsPerUser")
+		if err == nil {
+			//consider the value of tempPrxUsrSettings if it is a success
+			proxySettingsPerUser = tempPrxUsrSettings
 		}
+		k.Close()
+	}
+
+	var hkey registry.Key
+	if proxySettingsPerUser == 0 {
+		hkey = registry.LOCAL_MACHINE
+	} else {
+		hkey = registry.CURRENT_USER
+	}
+
+	k, err = registry.OpenKey(hkey, `Software\Microsoft\Windows\CurrentVersion\Internet Settings`, registry.QUERY_VALUE)
+	if err != nil {
+		return
 	}
 	defer k.Close()
 


### PR DESCRIPTION
…_MACHINE and CURRENT_USER

Following are the reasons to change the previous logic.
1> In Windows Service, if the program tries to access the CURRENT_USER, it is automatically diverted to HKEY_USERS\.DEFAULT. This results in a success and hence there is no error.
2> To avoid above issue, we no check the registry value 'ProxySettingsPerUser', which will help to decide which registry needs to be accessed. If the value of ProxySettingsPerUser is '1', it means it should use CURRENT_USER and if it is '0', it should use LOCAL_MACHINE.
