### PR TITLE
Pedantic bug fixes to WinHTTP fallthrough logic

### DIFF
--- a/ieproxy_windows.go
+++ b/ieproxy_windows.go
@@ -48,16 +48,9 @@ func writeConf() {
 			defer globalFreeWrapper(defaultCfg.lpszProxy)
 			defer globalFreeWrapper(defaultCfg.lpszProxyBypass)
 
-			// Changed, next 2 lines, so if that if we always set both of these (they are a pair, it doesn't make sense to set one here and keep the value of the other from above)
-			newProxy := StringFromUTF16Ptr(defaultCfg.lpszProxy)
-			if proxy == "" {
-				proxy = newProxy
-			}
-
-			newProxyByPass := StringFromUTF16Ptr(defaultCfg.lpszProxyBypass)
-			if proxyByPass == "" {
-				proxyByPass = newProxyByPass
-			}
+			// Always set both of these (they are a pair, it doesn't make sense to set one here and keep the value of the other from above)
+			proxy = StringFromUTF16Ptr(defaultCfg.lpszProxy)
+			proxyByPass = StringFromUTF16Ptr(defaultCfg.lpszProxyBypass)
 		}
 	}
 

--- a/ieproxy_windows.go
+++ b/ieproxy_windows.go
@@ -42,7 +42,7 @@ func writeConf() {
 		autoDetect = ieCfg.fAutoDetect
 	}
 
-	if proxy == "" { // <- new. Only fallback if we got NO proxy
+	if proxy == "" && !autoDetect{
 		// Try WinHTTP default proxy.
 		if defaultCfg, err := getDefaultProxyConfiguration(); err == nil {
 			defer globalFreeWrapper(defaultCfg.lpszProxy)


### PR DESCRIPTION
I noticed that we were falling through to reading the registry if we had no `proxy` AND `autoDetect` was false.  But we weren't taking `autoDetect` into account when falling back to WinHTTP.  That didn't seem right to me.  Reviewers, was the inconsistency deliberate? E.g. did we want to give callers the ability to have both `ProxyConf.Static` and `ProxyConf.Automatic` active at the same time?  If so, please reject this PR ;-)  (And let's add a comment instead, to explain why it should be inconsistent).

The other commit in this PR makes the fallback logic set _both_ of `proxy` and `proxyByPass` since they are logically a pair.  I believe this was part of the intent of #21 , but didn't make it into the code.  Again, reviewers, if you disagree pls reject this PR.