### PR TITLE
Implement configuration reload methods

### DIFF
--- a/ieproxy.go
+++ b/ieproxy.go
@@ -36,6 +36,11 @@ func GetConf() ProxyConf {
 	return getConf()
 }
 
+// ReloadConf reloads the proxy configuration
+func ReloadConf() ProxyConf {
+	return reloadConf()
+}
+
 // OverrideEnvWithStaticProxy writes new values to the
 // `http_proxy`, `https_proxy` and `no_proxy` environment variables.
 // The values are taken from the Windows Regedit (should be called in `init()` function - see example)

--- a/ieproxy_unix.go
+++ b/ieproxy_unix.go
@@ -6,5 +6,9 @@ func getConf() ProxyConf {
 	return ProxyConf{}
 }
 
+func reloadConf() ProxyConf {
+	return getConf()
+}
+
 func overrideEnvWithStaticProxy(pc ProxyConf, setenv envSetter) {
 }

--- a/ieproxy_windows.go
+++ b/ieproxy_windows.go
@@ -24,6 +24,12 @@ func getConf() ProxyConf {
 	return windowsProxyConf
 }
 
+// reloadConf forces a reload of the proxy configuration from the Windows registry
+func reloadConf() ProxyConf {
+	writeConf()
+	return getConf()
+}
+
 func writeConf() {
 	proxy := ""
 	proxyByPass := ""
@@ -42,7 +48,7 @@ func writeConf() {
 		autoDetect = ieCfg.fAutoDetect
 	}
 
-	if proxy == "" && !autoDetect{
+	if proxy == "" && !autoDetect {
 		// Try WinHTTP default proxy.
 		if defaultCfg, err := getDefaultProxyConfiguration(); err == nil {
 			defer globalFreeWrapper(defaultCfg.lpszProxy)


### PR DESCRIPTION
This pull requests implements a `ReloadConf()` method which allows re-reading the configuration. This is useful if one wants to re-read the proxy configuration (such as if a user's proxy configuration has changed due to a network change) without having to restart the entire program. 