### PR TITLE
Bugfix: null pointer panic

### DIFF
--- a/ieproxy_darwin.go
+++ b/ieproxy_darwin.go
@@ -73,7 +73,7 @@ func writeConf() {
 	}
 
 	cfNumHttpsEnable := C.CFNumberRef(C.CFDictionaryGetValue(cfDictProxy, unsafe.Pointer(C.kCFNetworkProxiesHTTPSEnable)))
-	if unsafe.Pointer(cfNumHttpEnable) != C.NULL && cfNumberGetGoInt(cfNumHttpsEnable) > 0 {
+	if unsafe.Pointer(cfNumHttpsEnable) != C.NULL && cfNumberGetGoInt(cfNumHttpsEnable) > 0 {
 		darwinProxyConf.Static.Active = true
 		if darwinProxyConf.Static.Protocols == nil {
 			darwinProxyConf.Static.Protocols = make(map[string]string)


### PR DESCRIPTION
<img width="1075" alt="image" src="https://user-images.githubusercontent.com/2050648/158054827-a84b5e11-84a7-4a52-94cd-3b9156ac881e.png">

```
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7fff416c48b9]

runtime stack:
runtime.throw({0x414c0d5, 0x7ffeefbff9f8})
        /usr/local/go/src/runtime/panic.go:1198 +0x71
runtime.sigpanic()
        /usr/local/go/src/runtime/signal_unix.go:719 +0x396

goroutine 1 [syscall]:
runtime.cgocall(0x410c800, 0xc00013dd00)
        /usr/local/go/src/runtime/cgocall.go:156 +0x5c fp=0xc00013dcd8 sp=0xc00013dca0 pc=0x400557c
github.com/mattn/go-ieproxy._Cfunc_CFNumberGetValue(0x0, 0x9, 0xc000182028)
        _cgo_gotypes.go:191 +0x49 fp=0xc00013dd00 sp=0xc00013dcd8 pc=0x410b109
github.com/mattn/go-ieproxy.cfNumberGetGoInt.func1(0x410b3e9, 0x410c8a0)
        /Users/yylyyl/go/pkg/mod/github.com/mattn/go-ieproxy@v0.0.3/ieproxy_darwin.go:43 +0x59 fp=0xc00013dd40 sp=0xc00013dd00 pc=0x410b899
github.com/mattn/go-ieproxy.cfNumberGetGoInt(0x0)
        /Users/yylyyl/go/pkg/mod/github.com/mattn/go-ieproxy@v0.0.3/ieproxy_darwin.go:43 +0x37 fp=0xc00013dd70 sp=0xc00013dd40 pc=0x410b817
github.com/mattn/go-ieproxy.writeConf()
        /Users/yylyyl/go/pkg/mod/github.com/mattn/go-ieproxy@v0.0.3/ieproxy_darwin.go:76 +0x275 fp=0xc00013de60 sp=0xc00013dd70 pc=0x410bd15
sync.(*Once).doSlow(0x403ea51, 0xc000032710)
        /usr/local/go/src/sync/once.go:68 +0xd2 fp=0xc00013dec8 sp=0xc00013de60 pc=0x4067b32
sync.(*Once).Do(...)
        /usr/local/go/src/sync/once.go:59
github.com/mattn/go-ieproxy.getConf(...)
        /Users/yylyyl/go/pkg/mod/github.com/mattn/go-ieproxy@v0.0.3/ieproxy_darwin.go:23
github.com/mattn/go-ieproxy.GetConf(...)
        /Users/yylyyl/go/pkg/mod/github.com/mattn/go-ieproxy@v0.0.3/ieproxy.go:36
main.main()
        /Users/yylyyl/Documents/gotest/main.go:7 +0x45 fp=0xc00013df80 sp=0xc00013dec8 pc=0x410c605
runtime.main()
        /usr/local/go/src/runtime/proc.go:255 +0x227 fp=0xc00013dfe0 sp=0xc00013df80 pc=0x4036b27
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1581 +0x1 fp=0xc00013dfe8 sp=0xc00013dfe0 pc=0x4062701

Process finished with the exit code 2
```

On macOS, if proxy for HTTP is enabled but proxy for HTTPS is disabled, this library would panic.

The reason is simple. Wrong variable is checked before accessing.
