### PR TITLE
Always reset active flag on macOS.

### DIFF
--- a/ieproxy_darwin.go
+++ b/ieproxy_darwin.go
@@ -58,6 +58,7 @@ func cfArrayGetGoStrings(cfArray C.CFArrayRef) []string {
 func writeConf() {
 	cfDictProxy := C.CFDictionaryRef(C.CFNetworkCopySystemProxySettings())
 	defer C.CFRelease(C.CFTypeRef(cfDictProxy))
+	darwinProxyConf.Static.Active = false
 
 	cfNumHttpEnable := C.CFNumberRef(C.CFDictionaryGetValue(cfDictProxy, unsafe.Pointer(C.kCFNetworkProxiesHTTPEnable)))
 	if unsafe.Pointer(cfNumHttpEnable) != C.NULL && cfNumberGetGoInt(cfNumHttpEnable) > 0 {


### PR DESCRIPTION
Previously, if the system configuration had proxies enabled, darwinProxyConf would get set to true. After that, even if ReloadConf() got called, there was nowhere in the code where that flag got reset, so it would stay active forever, which is incorrect behaviour.

Signed-off-by: Laura Brehm <laurabrehm@hey.com>