### PR TITLE
Reset static conf on writeConf()

### DIFF
--- a/ieproxy_darwin.go
+++ b/ieproxy_darwin.go
@@ -58,7 +58,7 @@ func cfArrayGetGoStrings(cfArray C.CFArrayRef) []string {
 func writeConf() {
 	cfDictProxy := C.CFDictionaryRef(C.CFNetworkCopySystemProxySettings())
 	defer C.CFRelease(C.CFTypeRef(cfDictProxy))
-	darwinProxyConf.Static.Active = false
+	darwinProxyConf = ProxyConf{}
 
 	cfNumHttpEnable := C.CFNumberRef(C.CFDictionaryGetValue(cfDictProxy, unsafe.Pointer(C.kCFNetworkProxiesHTTPEnable)))
 	if unsafe.Pointer(cfNumHttpEnable) != C.NULL && cfNumberGetGoInt(cfNumHttpEnable) > 0 {


### PR DESCRIPTION
Previously, if system proxy was enabled, darwinProxyConf.Static.Protocols got populated with the proxy configuration. If afterwards the system configuration was removed there was no place in the code where the map got reset, which led to incorrect configurations being returned even after calling ReloadConf()

My previous PR addressed darwinProxyConf.Static.Enabled remaining true after this, but still left incorrect behaviour in regards to the darwinProxyConf.Static.Protocols map not being reset if system proxies are disabled. The behaviour should be correct now as the var just gets reset at the start of writeConf()

Signed-off-by: Laura Brehm <laurabrehm@hey.com>