### PR TITLE
fix: prevent processing pac file if wrong url

### DIFF
--- a/darwin_test.go
+++ b/darwin_test.go
@@ -32,38 +32,53 @@ func TestPacfile(t *testing.T) {
 		expected string
 	}{
 		{
-			"direct.pac",
+			serverBase + "direct.pac",
 			"http://google.com",
 			"",
 		},
 		{
-			"404.pac",
+			serverBase + "404.pac",
 			"http://google.com",
 			"",
 		},
 		{
-			"simple.pac",
+			serverBase + "simple.pac",
 			"http://google.com",
 			"127.0.0.1:8",
 		},
 		{
-			"multiple.pac",
+			serverBase + "multiple.pac",
 			"http://google.com",
 			"127.0.0.1:8081",
 		},
 		{
-			"except.pac",
+			serverBase + "except.pac",
 			"http://imgur.com",
 			"localhost:9999",
 		},
 		{
-			"except.pac",
+			serverBase + "except.pac",
+			"http://example.com",
+			"",
+		},
+		{
+			"",
+			"http://example.com",
+			"",
+		},
+		{
+			" ",
+			"http://example.com",
+			"",
+		},
+		{
+			"wrong_format",
 			"http://example.com",
 			"",
 		},
 	}
 	for _, p := range pacSet {
-		proxy.PreConfiguredURL = serverBase + p.pacfile
+		proxy.PreConfiguredURL = p.pacfile
 		out := proxy.FindProxyForURL(p.url)
 		if out != p.expected {
 			t.Error("Got: ", out, "Expected: ", p.expected)

--- a/pac_darwin.go
+++ b/pac_darwin.go
@@ -98,7 +98,10 @@ char* _getPacUrl() {
 
 */
 import "C"
-import "unsafe"
+import (
+	"net/url"
+	"unsafe"
+)
 
 func (psc *ProxyScriptConf) findProxyForURL(URL string) string {
 	if !psc.Active {
@@ -108,15 +111,18 @@ func (psc *ProxyScriptConf) findProxyForURL(URL string) string {
 	return proxy
 }
 
-func getProxyForURL(pacFileURL, url string) string {
+func getProxyForURL(pacFileURL, targetURL string) string {
 	if pacFileURL == "" {
 		pacFileURL = getPacUrl()
 	}
 	if pacFileURL == "" {
 		return ""
 	}
+	if u, err := url.Parse(pacFileURL); err != nil || u.Scheme == "" {
+		return ""
+	}
 
-	csUrl := C.CString(url)
+	csUrl := C.CString(targetURL)
 	csPac := C.CString(pacFileURL)
 	csRet := C._getProxyUrlFromPac(csPac, csUrl)
 

--- a/windows_test.go
+++ b/windows_test.go
@@ -209,38 +209,53 @@ func TestPacfile(t *testing.T) {
 		expected string
 	}{
 		{
-			"direct.pac",
+			serverBase + "direct.pac",
 			"http://google.com",
 			"",
 		},
 		{
-			"404.pac",
+			serverBase + "404.pac",
 			"http://google.com",
 			"",
 		},
 		{
-			"simple.pac",
+			serverBase + "simple.pac",
 			"http://google.com",
 			"127.0.0.1:8",
 		},
 		{
-			"multiple.pac",
+			serverBase + "multiple.pac",
 			"http://google.com",
 			"127.0.0.1:8081",
 		},
 		{
-			"except.pac",
+			serverBase + "except.pac",
 			"http://imgur.com",
 			"localhost:9999",
 		},
 		{
-			"except.pac",
+			serverBase + "except.pac",
+			"http://example.com",
+			"",
+		},
+		{
+			"",
+			"http://example.com",
+			"",
+		},
+		{
+			" ",
+			"http://example.com",
+			"",
+		},
+		{
+			"wrong_format",
 			"http://example.com",
 			"",
 		},
 	}
 	for _, p := range pacSet {
-		proxy.PreConfiguredURL = serverBase + p.pacfile
+		proxy.PreConfiguredURL = p.pacfile
 		out := proxy.FindProxyForURL(p.url)
 		if out != p.expected {
 			t.Error("Got: ", out, "Expected: ", p.expected)


### PR DESCRIPTION
Signed-off-by: Maxime CLEMENT <maxime.clement@docker.com>

---

Add safe guard using URL parsing for Mac when resolving proxy using PAC file. MacOS accept literally anything in the PAC URL input from System Preferences.

---
We have encountered a user having PAC location set to ` `, which make the whole thing panic.

I've made the `Scheme` required because sadly `url.Parse` often returns no error, as explained in the [documentation ](https://pkg.go.dev/net/url#Parse):

> The url may be relative (a path, without a host) or absolute (starting with a scheme). Trying to parse a hostname and path without a scheme is invalid but may not necessarily return an error, due to parsing ambiguities.

However, looking for PAC location without `Scheme` does not make sense here, so I guess we're fine.

Windows do not seems to have such flaws, I'm assuming `WinHttpGetProxyForUrl` handle it correctly.

Anyway, I've added unit test for both operating systems, just in case of future regressions.

I would be glad if this could land into a future release so we could use this upstream instead of fork as a patch 😅 

