### PR TITLE
fix: darwin PAC proxy for https:// URL

### DIFF
--- a/darwin_test.go
+++ b/darwin_test.go
@@ -48,6 +48,11 @@ func TestPacfile(t *testing.T) {
 			"127.0.0.1:8",
 		},
 		{
+			serverBase + "simple.pac",
+			"https://google.com",
+			"127.0.0.1:8",
+		},
+		{
 			serverBase + "multiple.pac",
 			"http://google.com",
 			"127.0.0.1:8081",

--- a/pac_darwin.go
+++ b/pac_darwin.go
@@ -66,6 +66,20 @@ char* _getProxyUrlFromPac(char* pac, char* reqCs) {
 
 					sprintf(retCString, "%s:%d", host_str, port_int);
 				}
+				if (CFEqual(pxyType, kCFProxyTypeHTTPS)) {
+					CFStringRef host = (CFStringRef)CFDictionaryGetValue(pxy, kCFProxyHostNameKey);
+					CFNumberRef port = (CFNumberRef)CFDictionaryGetValue(pxy, kCFProxyPortNumberKey);
+
+					char host_str[STR_LEN - 16];
+					CFStringGetCString(host, host_str, STR_LEN - 16, kCFStringEncodingUTF8);
+
+					int port_int = 443;
+					if (port) {
+							CFNumberGetValue(port, kCFNumberIntType, &port_int);
+					}
+
+					sprintf(retCString, "%s:%d", host_str, port_int);
+				}
 			}
 		} else {
 			// error


### PR DESCRIPTION
For a URL https://www.google.com and a PAC file which returns `PROXY host:port`, Darwin will return a proxy type of `kCFProxyTypeHTTPS` which the header defines as

```
kCFProxyTypeHTTPS - the proxy is a tunneling proxy as used for HTTPS
```
i.e. it will tunnel the https through `HTTP CONNECT`
