### PR TITLE
Fix build constraints since windows does not depend on cgo

### DIFF
--- a/ieproxy_unix.go
+++ b/ieproxy_unix.go
@@ -1,4 +1,4 @@
-//go:build (!windows && !darwin) || !cgo
+//go:build !windows && (!darwin || !cgo)
 // +build !windows,!darwin !cgo
 
 package ieproxy

--- a/pac_unix.go
+++ b/pac_unix.go
@@ -1,4 +1,4 @@
-//go:build (!windows && !darwin) || !cgo
+//go:build !windows && (!darwin || !cgo)
 // +build !windows,!darwin !cgo
 
 package ieproxy


### PR DESCRIPTION
The build constraints in ieproxy_unix and pac_unix are incorrect. 

The windows implementation does not depend on cgo, only the darwin one does. 

Based off the following logic this should be the build constraint on this file, otherwise Windows architectures with cgo disabled by default will not build correctly, resulting in an error like this 
```
# github.com/mattn/go-ieproxy
../../../go/pkg/mod/github.com/mattn/go-ieproxy@v0.0.9/ieproxy_windows.go:22:6: getConf redeclared in this block
	../../../go/pkg/mod/github.com/mattn/go-ieproxy@v0.0.9/ieproxy_unix.go:6:6: other declaration of getConf
../../../go/pkg/mod/github.com/mattn/go-ieproxy@v0.0.9/ieproxy_windows.go:28:6: reloadConf redeclared in this block
	../../../go/pkg/mod/github.com/mattn/go-ieproxy@v0.0.9/ieproxy_unix.go:10:6: other declaration of reloadConf
../../../go/pkg/mod/github.com/mattn/go-ieproxy@v0.0.9/ieproxy_windows.go:133:6: overrideEnvWithStaticProxy redeclared in this block
	../../../go/pkg/mod/github.com/mattn/go-ieproxy@v0.0.9/ieproxy_unix.go:14:6: other declaration of overrideEnvWithStaticProxy
../../../go/pkg/mod/github.com/mattn/go-ieproxy@v0.0.9/pac_windows.go:9:29: ProxyScriptConf.findProxyForURL redeclared in this block
	../../../go/pkg/mod/github.com/mattn/go-ieproxy@v0.0.9/pac_unix.go:6:29: other declaration of findProxyForURL
```

!(windows || (darwin && cgo)) = !windows && !(darwin && cgo) = !windows && (!darwin || !cgo) = !windows,!darwin !cgo

//go:build !windows && (!darwin || !cgo)
// +build !windows,!darwin !cgo


I believe this should resolve https://github.com/mattn/go-ieproxy/issues/45 as well
