### PR TITLE
Correct `+build` directives to match `go:build` directives

### DIFF
--- a/ieproxy_unix.go
+++ b/ieproxy_unix.go
@@ -1,5 +1,6 @@
 //go:build !windows && (!darwin || !cgo)
-// +build !windows,!darwin !cgo
+// +build !windows
+// +build !darwin !cgo
 
 package ieproxy
 

--- a/pac_unix.go
+++ b/pac_unix.go
@@ -1,5 +1,6 @@
 //go:build !windows && (!darwin || !cgo)
-// +build !windows,!darwin !cgo
+// +build !windows
+// +build !darwin !cgo
 
 package ieproxy
 


### PR DESCRIPTION
The new-style `go:build` directives in some files make use of parentheses to bind `||` before `&&` in their conditionals. The equivalent of this in the old-style `+build` directives is to use multi-line directives, as described on SO here:
https://stackoverflow.com/questions/10646531/golang-conditional-compilation/67937234#67937234

This was tripping `go vet` and blocking building against this repo as a dep for me.